### PR TITLE
Check that we have a SOA reply before returning it

### DIFF
--- a/src/check_dns_sync/check_dns_sync.py
+++ b/src/check_dns_sync/check_dns_sync.py
@@ -29,8 +29,16 @@ def query_from_authority(zone):
     if not len(answers):
         raise nagiosplugin.CheckError("No result. Domain probably does not exist")
 
-    answers = answers.strip().splitlines()
-    return [(int(arguments[3]), arguments[10]) for arguments in (answer.split() for answer in answers)]
+    answers = answers.split('\n')
+    returned_answer = []
+    for answer in answers:
+        if len(answer) > 0:
+            if not 'SOA ' in answer:
+                raise nagiosplugin.CheckError(f"No parsable SOA: {answer}")
+            else:
+                answer = answer.split()
+                returned_answer.append((int(answer[3]), answer[10]))
+    return returned_answer
 
 
 def query(zone, nameserver):


### PR DESCRIPTION
```python
alarig@x280 check_dns_sync % (master =) python src/check_dns_sync/check_dns_sync.py -vvv -z alarig.fr
CHECKDNSSYNC UNKNOWN: ValueError: invalid literal for int() with base 10: 'from'
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/nagiosplugin/runtime.py", line 45, in wrapper
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/alarig/Documents/git/github/alarig/check_dns_sync/src/check_dns_sync/check_dns_sync.py", line 130, in main
    check.main()
  File "/usr/lib/python3.12/site-packages/nagiosplugin/check.py", line 122, in main
    runtime.execute(self, verbose, timeout)
  File "/usr/lib/python3.12/site-packages/nagiosplugin/runtime.py", line 132, in execute
    self.run(check)
  File "/usr/lib/python3.12/site-packages/nagiosplugin/runtime.py", line 119, in run
    check()
  File "/usr/lib/python3.12/site-packages/nagiosplugin/check.py", line 107, in __call__
    self._evaluate_resource(resource)
  File "/usr/lib/python3.12/site-packages/nagiosplugin/check.py", line 81, in _evaluate_resource
    for metric in metrics:
  File "/home/alarig/Documents/git/github/alarig/check_dns_sync/src/check_dns_sync/check_dns_sync.py", line 68, in probe
    serials = query_from_authority(self.zone)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alarig/Documents/git/github/alarig/check_dns_sync/src/check_dns_sync/check_dns_sync.py", line 33, in query_from_authority
    return [(int(arguments[3]), arguments[10]) for arguments in (answer.split() for answer in answers)]
             ^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'from'
zsh: exit 3     python src/check_dns_sync/check_dns_sync.py -vvv -z alarig.fr
```

```
alarig@x280 check_dns_sync % (master =) python src/check_dns_sync/check_dns_sync.py -vvv -z alarig.fr                  
CHECKDNSSYNC UNKNOWN - No parsable SOA: ;; no response from 91.224.149.128
zsh: exit 3     python src/check_dns_sync/check_dns_sync.py -vvv -z alarig.fr
alarig@x280 check_dns_sync % (master =) python src/check_dns_sync/check_dns_sync.py -vvv -z icedtux.no                 
CHECKDNSSYNC OK - All zone are in sync | '173.246.100.2'=0 version behind;;@1:;0 '2001:4b98:aaaa::2'=0 version behind;;@1:;0 '2001:4b98:aaab::2'=0 version behind;;@1:;0 '213.167.230.2'=0 version behind;;@1:;0 '217.70.187.2'=0 version behind;;@1:;0 '2604:3400:aaac::2'=0 version behind;;@1:;0 '2a0e:f42::1'=0 version behind;;@1:;0 '45.91.126.1'=0 version behind;;@1:;0
```